### PR TITLE
Rubyプラクティス > カレンダーのプログラムの課題としてcal.rbを追加した

### DIFF
--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -1,6 +1,7 @@
 #! /usr/bin/env ruby
 
 require 'date'
+require 'optparse'
 
 # $ ./cal.rb -m 11
 #       11月 2019
@@ -12,28 +13,19 @@ require 'date'
 # 24 25 26 27 28 29 30
 
 # -m  -y で月と年を指定してカレンダーを表示できるようにする
-arg_month = nil
-arg_year = nil
-ARGV.each_with_index do |arg, index|
-  if arg == '-m'
-    arg_month = ARGV[index + 1]
-  elsif arg == '-y'
-    arg_year = ARGV[index + 1]
-  end
-end
-
-year = arg_year&.to_i || Date.today.year
-month = arg_month&.to_i || Date.today.month
-
+options = ARGV.getopts('m:', 'y:')
+year = options['y']&.to_i || Date.today.year
+month = options['m']&.to_i || Date.today.month
+# 指定年月の初日と最終日を取得
 start_date = Date.new(year, month, 1)
 end_date = Date.new(year, month, -1)
-dates = (start_date..end_date).to_a
 
+# 指定年月のカレンダーを描画する
 puts "#{month}月 #{year}".center(21)
-puts ' 日 月 火 水 木 金 土 '
+puts '日 月 火 水 木 金 土'
 print ' '.rjust(3) * start_date.wday # 月の初日の曜日まで空白で埋め
 (start_date..end_date).each do |day|
-  print day.day.to_s.rjust(3)
-  print "\n" if day.saturday?
+  print "#{day.day.to_s.rjust(2)} "
+  puts if day.saturday?
 end
 print "\n"

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -36,3 +36,4 @@ print ' '.rjust(3) * start_date.wday # 月の初日の曜日まで空白で埋�
   print day.day.to_s.rjust(3)
   print "\n" if day.saturday?
 end
+print "\n"

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -27,10 +27,11 @@ month = arg_month&.to_i || Date.today.month
 
 start_date = Date.new(year, month, 1)
 end_date = Date.new(year, month, -1)
+dates = (start_date..end_date).to_a
 
-puts "#{month}月 #{year}"
-puts '日 月 火 水 木 金 土'
-# TODO: 表示を調整する
+puts "#{month}月 #{year}".center(21)
+puts ' 日 月 火 水 木 金 土 '
+print ' '.rjust(3) * start_date.wday # 月の初日の曜日まで空白で埋め
 (start_date..end_date).each do |day|
   print day.day.to_s.rjust(3)
   print "\n" if day.saturday?

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -28,4 +28,4 @@ print ' '.rjust(3) * start_date.wday # 月の初日の曜日まで空白で埋�
   print "#{day.day.to_s.rjust(2)} "
   puts if day.saturday?
 end
-print "\n"
+puts

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -3,24 +3,35 @@
 require 'date'
 
 # $ ./cal.rb -m 11
-#       11月 2019        
-# 日 月 火 水 木 金 土  
-#                 1  2  
-#  3  4  5  6  7  8  9  
-# 10 11 12 13 14 15 16  
-# 17 18 19 20 21 22 23  
+#       11月 2019
+# 日 月 火 水 木 金 土
+#                 1  2
+#  3  4  5  6  7  8  9
+# 10 11 12 13 14 15 16
+# 17 18 19 20 21 22 23
 # 24 25 26 27 28 29 30
 
 # -m  -y で月と年を指定してカレンダーを表示できるようにする
-month = nil
-year = nil
+arg_month = nil
+arg_year = nil
 ARGV.each_with_index do |arg, index|
   if arg == '-m'
-    month = ARGV[index + 1]
+    arg_month = ARGV[index + 1]
   elsif arg == '-y'
-    year = ARGV[index + 1]
+    arg_year = ARGV[index + 1]
   end
 end
 
-puts "Month: #{month}"
-puts "Year: #{year}"
+year = arg_year&.to_i || Date.today.year
+month = arg_month&.to_i || Date.today.month
+
+start_date = Date.new(year, month, 1)
+end_date = Date.new(year, month, -1)
+
+puts "#{month}月 #{year}"
+puts '日 月 火 水 木 金 土'
+# TODO: 表示を調整する
+(start_date..end_date).each do |day|
+  print day.day.to_s.rjust(3)
+  print "\n" if day.saturday?
+end

--- a/02.calendar/cal.rb
+++ b/02.calendar/cal.rb
@@ -1,0 +1,26 @@
+#! /usr/bin/env ruby
+
+require 'date'
+
+# $ ./cal.rb -m 11
+#       11月 2019        
+# 日 月 火 水 木 金 土  
+#                 1  2  
+#  3  4  5  6  7  8  9  
+# 10 11 12 13 14 15 16  
+# 17 18 19 20 21 22 23  
+# 24 25 26 27 28 29 30
+
+# -m  -y で月と年を指定してカレンダーを表示できるようにする
+month = nil
+year = nil
+ARGV.each_with_index do |arg, index|
+  if arg == '-m'
+    month = ARGV[index + 1]
+  elsif arg == '-y'
+    year = ARGV[index + 1]
+  end
+end
+
+puts "Month: #{month}"
+puts "Year: #{year}"


### PR DESCRIPTION
## 背景

- Rubyプラクティス > カレンダーのプログラムの課題として指定年月（デフォルト当月）のカレンダー表示をする cal.rb を追加する

```
今月のカレンダーを表示するプログラムを書いてみよう。（コマンドラインのプログラムとして作ろう）
```

期待する結果
```
$ ./cal.rb -m 11
      11月 2019        
日 月 火 水 木 金 土  
                1  2  
 3  4  5  6  7  8  9  
10 11 12 13 14 15 16  
17 18 19 20 21 22 23  
24 25 26 27 28 29 30
```

```
$ ./cal.rb -y 2020 -m 11 
      11月 2020        
日 月 火 水 木 金 土  
 1  2  3  4  5  6  7  
 8  9 10 11 12 13 14  
15 16 17 18 19 20 21  
22 23 24 25 26 27 28  
29 30
```

## やったこと

- [x] 02.calendar/cal.rb として指定年月（デフォルト当月）でカレンダー表示をするプログラムを追加した

## 確認方法

`./cal.rb` を実行して期待した出力になっていること

![CleanShot 2024-10-03 at 16 06 38@2x](https://github.com/user-attachments/assets/b15be50f-db3c-48a0-83bc-b7c2dbb7e4c8)
