### PR TITLE
Rubyプラクティス > ボウリングのスコア計算プログラムとしてbowling.rbを追加した

### DIFF
--- a/03.bowling/bowling.rb
+++ b/03.bowling/bowling.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'debug'
 

--- a/03.bowling/bowling.rb
+++ b/03.bowling/bowling.rb
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+require 'debug'
+
 # % ./bowling.rb 6,3,9,0,0,3,8,2,7,3,X,9,1,8,0,X,6,4,5
 # 139
 # % ./bowling.rb 6,3,9,0,0,3,8,2,7,3,X,9,1,8,0,X,X,X,X
@@ -35,13 +37,33 @@ shots.each_slice(2) do |s|
 end
 
 point = 0
-frames.each do |frame|
-  point += if frame[0] == 10 # strike
-             30
-           elsif frame.sum == 10 # spare
-             frame[0] + 10
-           else
-             frame.sum
-           end
+
+frames.each_with_index do |frame, index|
+  next_frame = frames[index + 1]
+  add_point = if index > 8
+                frame.sum
+              elsif frame[0] == 10
+                pp 'strike'
+                # ストライクの場合は次の2投分を加算する
+                if next_frame
+                  if next_frame[0] == 10 && frames[index + 2]
+                    frame.sum + next_frame.sum + frames[index + 2][0]
+                  else
+                    frame.sum + next_frame.sum
+                  end
+                else
+                  frame.sum
+                end # strike
+              elsif frame.sum == 10 # spare
+                pp 'spare'
+                # スペアの場合は次の1投分を加算する
+                frame.sum + next_frame[0]
+              else
+                frame.sum
+              end
+
+  pp add_point
+  point += add_point
+  pp point
 end
 puts point

--- a/03.bowling/bowling.rb
+++ b/03.bowling/bowling.rb
@@ -39,31 +39,20 @@ end
 point = 0
 
 frames.each_with_index do |frame, index|
-  next_frame = frames[index + 1]
-  add_point = if index > 8
-                frame.sum
-              elsif frame[0] == 10
-                pp 'strike'
-                # ストライクの場合は次の2投分を加算する
-                if next_frame
-                  if next_frame[0] == 10 && frames[index + 2]
-                    frame.sum + next_frame.sum + frames[index + 2][0]
-                  else
-                    frame.sum + next_frame.sum
-                  end
-                else
-                  frame.sum
-                end # strike
-              elsif frame.sum == 10 # spare
-                pp 'spare'
-                # スペアの場合は次の1投分を加算する
-                frame.sum + next_frame[0]
-              else
-                frame.sum
-              end
+  # 10フレーム以降は単純に加算する
+  next point += frame.sum if index + 1 >= 10
+  # スペアでもストライクでもない場合は単純に加算する
+  next point += frame.sum if frame[0] != 10 && frame.sum != 10
+  # スペアの場合は自フレームの得点と次フレームの1投目を加算する
+  next point += frame.sum + frames[index + 1][0] if frame[0] != 10
 
-  pp add_point
-  point += add_point
-  pp point
+  # ストライクの場合は次の2投分を加算する
+  point +=
+    # 次フレームがストライクの場合は、次フレーム+その次のフレームの1投分を加算する
+    if frames[index + 1][0] == 10
+      frame.sum + frames[index + 1].sum + frames[index + 2][0]
+    else
+      frame.sum + frames[index + 1].sum
+    end
 end
 puts point

--- a/03.bowling/bowling.rb
+++ b/03.bowling/bowling.rb
@@ -1,0 +1,47 @@
+#!/usr/bin/env ruby
+
+# % ./bowling.rb 6,3,9,0,0,3,8,2,7,3,X,9,1,8,0,X,6,4,5
+# 139
+# % ./bowling.rb 6,3,9,0,0,3,8,2,7,3,X,9,1,8,0,X,X,X,X
+# 164
+# % ./bowling.rb 0,10,1,5,0,0,0,0,X,X,X,5,1,8,1,0,4
+# 107
+# % ./bowling.rb 6,3,9,0,0,3,8,2,7,3,X,9,1,8,0,X,X,0,0
+# 134
+# % ./bowling.rb 6,3,9,0,0,3,8,2,7,3,X,9,1,8,0,X,X,1,8
+# 144
+# % ./bowling.rb X,X,X,X,X,X,X,X,X,X,X,X
+# 300
+# % ./bowling.rb X,X,X,X,X,X,X,X,X,X,X,2
+# 292
+# % ./bowling.rb X,0,0,X,0,0,X,0,0,X,0,0,X,0,0
+# 50
+
+score = ARGV[0]
+scores = score.split(',')
+shots = []
+scores.each do |s|
+  if s == 'X'
+    shots << 10
+    shots << 0
+  else
+    shots << s.to_i
+  end
+end
+
+frames = []
+shots.each_slice(2) do |s|
+  frames << s
+end
+
+point = 0
+frames.each do |frame|
+  point += if frame[0] == 10 # strike
+             30
+           elsif frame.sum == 10 # spare
+             frame[0] + 10
+           else
+             frame.sum
+           end
+end
+puts point


### PR DESCRIPTION
## 背景

Rubyプラクティス > カレンダーのプログラムの課題としてボウリングのスコア計算プログラム(旧ルール)を追加した

```
あるボウリングの結果からスコアの数値を出力しよう。
```

期待する結果
```
% ./bowling.rb 6,3,9,0,0,3,8,2,7,3,X,9,1,8,0,X,6,4,5
139
% ./bowling.rb 6,3,9,0,0,3,8,2,7,3,X,9,1,8,0,X,X,X,X
164
% ./bowling.rb 0,10,1,5,0,0,0,0,X,X,X,5,1,8,1,0,4
107
% ./bowling.rb 6,3,9,0,0,3,8,2,7,3,X,9,1,8,0,X,X,0,0
134
% ./bowling.rb 6,3,9,0,0,3,8,2,7,3,X,9,1,8,0,X,X,1,8
144
% ./bowling.rb X,X,X,X,X,X,X,X,X,X,X,X
300
% ./bowling.rb X,X,X,X,X,X,X,X,X,X,X,2
292
% ./bowling.rb X,0,0,X,0,0,X,0,0,X,0,0,X,0,0
50
```

## やったこと

- [x] 旧ルールのボウリングスコア計算プログラムとして 03.bowling/bowling.rb を追加した
    - [x] サンプルの新ルールのボウリングスコア計算プログラムを土台に、旧ルールに適合するようコードを整理した
        - [x] 10フレーム以降はボーナス無しの単純加算をする
        - [x] スペアの場合は次フレームの1投目の得点をボーナス加算する
        - [x] ストライクの場合は続く2投分の得点をボーナス加算する（次フレームがストライクなら、次々フレームの1投目までボーナス加算する）
    - [x] rubocop-fjord でのautocorrectを実行した

## 確認方法

サンプルスコアで./bowling.rb を実行し、結果が一致していること

![CleanShot 2024-10-03 at 18 17 56@2x](https://github.com/user-attachments/assets/8f165a53-bc54-4ba3-928f-f2bd8fc3ea90)
