### PR TITLE
Rubyプラクティス > lsコマンドを作る2 として -aオプション機能を追加した

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -6,28 +6,34 @@ require 'optparse'
 COLUMN_SIZE = 3
 PADDING_MARGIN = 1
 
-options = ARGV.getopts('a')
+argv_options = ARGV.getopts('a')
 
-def get_file_names(options)
+def main(options = {})
+  file_names = file_names(options)
+
+  padding_size = file_names.map(&:length).max + PADDING_MARGIN
+
+  lack_count = file_names.length % COLUMN_SIZE
+  file_names.concat([''] * (COLUMN_SIZE - lack_count)) if lack_count.positive?
+
+  row_size = (file_names.length / COLUMN_SIZE)
+  matrix = file_names.each_slice(row_size).to_a.transpose
+  matrix.each do |row_file_names|
+    row_file_names.each do |file_name|
+      print file_name.ljust(padding_size)
+    end
+    puts
+  end
+end
+
+def file_names(options = {})
   file_names = Dir.entries(__dir__)
+  sorted_file_names = file_names.sort
   if options['a']
-    file_names.sort
+    sorted_file_names
   else
-    file_names.sort.reject { |file_name| file_name.start_with?('.') }
+    sorted_file_names.reject { |file_name| file_name.start_with?('.') }
   end
 end
 
-file_names = get_file_names(options)
-padding_size = file_names.map(&:length).max + PADDING_MARGIN
-
-lack_count = file_names.length % COLUMN_SIZE
-file_names.concat([''] * (COLUMN_SIZE - lack_count)) if lack_count.positive?
-
-row_size = (file_names.length / COLUMN_SIZE)
-matrix = file_names.each_slice(row_size).to_a.transpose
-matrix.each do |row_file_names|
-  row_file_names.each do |file_name|
-    print file_name.ljust(padding_size)
-  end
-  puts
-end
+main(argv_options)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -6,10 +6,9 @@ require 'optparse'
 COLUMN_SIZE = 3
 PADDING_MARGIN = 1
 
-argv_options = ARGV.getopts('a')
-
-def main(options = {})
-  file_names = file_names(options)
+def main
+  options = ARGV.getopts('a')
+  file_names = generate_file_names(options)
 
   padding_size = file_names.map(&:length).max + PADDING_MARGIN
 
@@ -26,14 +25,9 @@ def main(options = {})
   end
 end
 
-def file_names(options = {})
-  file_names = Dir.entries(__dir__)
-  sorted_file_names = file_names.sort
-  if options['a']
-    sorted_file_names
-  else
-    sorted_file_names.reject { |file_name| file_name.start_with?('.') }
-  end
+def generate_file_names(options = {})
+  file_names = Dir.entries(__dir__).sort
+  options['a'] ? file_names : file_names.reject { |file_name| file_name.start_with?('.') }
 end
 
-main(argv_options)
+main

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,12 +1,23 @@
 #! /usr/bin/env ruby
 # frozen_string_literal: true
 
+require 'optparse'
+
 COLUMN_SIZE = 3
 PADDING_MARGIN = 1
 
-file_names = Dir.children(__dir__)
-sorted_file_names = file_names.sort.reject { |file_name| file_name.start_with?('.') }
+options = ARGV.getopts('a')
 
+def get_sorted_file_names(options)
+  file_names = Dir.entries(__dir__)
+  if options['a']
+    file_names.sort
+  else
+    file_names.sort.reject { |file_name| file_name.start_with?('.') }
+  end
+end
+
+sorted_file_names = get_sorted_file_names(options)
 padding_size = sorted_file_names.map(&:length).max + PADDING_MARGIN
 
 lack_count = sorted_file_names.length % COLUMN_SIZE

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -8,7 +8,7 @@ PADDING_MARGIN = 1
 
 options = ARGV.getopts('a')
 
-def get_sorted_file_names(options)
+def get_file_names(options)
   file_names = Dir.entries(__dir__)
   if options['a']
     file_names.sort
@@ -17,14 +17,14 @@ def get_sorted_file_names(options)
   end
 end
 
-sorted_file_names = get_sorted_file_names(options)
-padding_size = sorted_file_names.map(&:length).max + PADDING_MARGIN
+file_names = get_file_names(options)
+padding_size = file_names.map(&:length).max + PADDING_MARGIN
 
-lack_count = sorted_file_names.length % COLUMN_SIZE
-sorted_file_names.concat([''] * (COLUMN_SIZE - lack_count)) if lack_count.positive?
+lack_count = file_names.length % COLUMN_SIZE
+file_names.concat([''] * (COLUMN_SIZE - lack_count)) if lack_count.positive?
 
-row_size = (sorted_file_names.length / COLUMN_SIZE)
-matrix = sorted_file_names.each_slice(row_size).to_a.transpose
+row_size = (file_names.length / COLUMN_SIZE)
+matrix = file_names.each_slice(row_size).to_a.transpose
 matrix.each do |row_file_names|
   row_file_names.each do |file_name|
     print file_name.ljust(padding_size)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -4,19 +4,19 @@
 COLUMN_SIZE = 3
 PADDING_MARGIN = 1
 
-items = Dir.children(__dir__)
-sorted_items = items.sort.reject { |item| item.start_with?('.') }
+file_names = Dir.children(__dir__)
+sorted_file_names = file_names.sort.reject { |file_name| file_name.start_with?('.') }
 
-padding_size = sorted_items.map(&:length).max + PADDING_MARGIN
+padding_size = sorted_file_names.map(&:length).max + PADDING_MARGIN
 
-lack_count = sorted_items.length % COLUMN_SIZE
-sorted_items.concat([''] * (COLUMN_SIZE - lack_count)) if lack_count.positive?
+lack_count = sorted_file_names.length % COLUMN_SIZE
+sorted_file_names.concat([''] * (COLUMN_SIZE - lack_count)) if lack_count.positive?
 
-row_size = (sorted_items.length / COLUMN_SIZE)
-matrix = sorted_items.each_slice(row_size).to_a.transpose
-matrix.each do |row_items|
-  row_items.each do |item|
-    print item.ljust(padding_size)
+row_size = (sorted_file_names.length / COLUMN_SIZE)
+matrix = sorted_file_names.each_slice(row_size).to_a.transpose
+matrix.each do |row_file_names|
+  row_file_names.each do |file_name|
+    print file_name.ljust(padding_size)
   end
   puts
 end


### PR DESCRIPTION
## 背景
- #4
- で作成した ls.rb に ls -a 相当のオプション機能を追加したい

## やったこと
- [x] -a オプションを指定してファイル名一覧を表示できるようにした
- [x] items という変数名を file_names に差し替えた

## 確認方法

ディレクトリに移動して ./ls.rb - aでファイル一覧を表示できること

```sh
$ cd 04.ls
$ ./ls.rb -a
```

- 実行結果
  - ![CleanShot 2024-10-17 at 12 09 52@2x](https://github.com/user-attachments/assets/1e16cfc0-4cc5-463b-8d88-271d146b0f1c)
- lsコマンドとの比較
  - ![CleanShot 2024-10-17 at 11 51 05@2x](https://github.com/user-attachments/assets/f4f606c8-1b44-4f70-94b7-b9055fb56888)
- rubocop実行結果
  - ![CleanShot 2024-10-17 at 12 06 46@2x](https://github.com/user-attachments/assets/b6e7a8f3-52a2-43e6-8ecc-a2c2b2fb0270)
