### PR TITLE
Rubyプラクティス > lsコマンドを作る3 として -rオプション機能を追加した

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -7,7 +7,7 @@ COLUMN_SIZE = 3
 PADDING_MARGIN = 1
 
 def main
-  options = ARGV.getopts('a')
+  options = ARGV.getopts('ar')
   file_names = search_file_names(options)
 
   padding_size = file_names.map(&:length).max + PADDING_MARGIN
@@ -27,7 +27,8 @@ end
 
 def search_file_names(options = {})
   file_names = Dir.entries(__dir__).sort
-  options['a'] ? file_names : file_names.reject { |file_name| file_name.start_with?('.') }
+  filtered_file_names = options['a'] ? file_names : file_names.reject { |file_name| file_name.start_with?('.') }
+  options['r'] ? filtered_file_names.reverse : filtered_file_names
 end
 
 main

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -8,7 +8,7 @@ PADDING_MARGIN = 1
 
 def main
   options = ARGV.getopts('a')
-  file_names = generate_file_names(options)
+  file_names = search_file_names(options)
 
   padding_size = file_names.map(&:length).max + PADDING_MARGIN
 
@@ -25,7 +25,7 @@ def main
   end
 end
 
-def generate_file_names(options = {})
+def search_file_names(options = {})
   file_names = Dir.entries(__dir__).sort
   options['a'] ? file_names : file_names.reject { |file_name| file_name.start_with?('.') }
 end


### PR DESCRIPTION
## 背景
- #5
  - で追加開発したlsスクリプトに ls -r 相当のオプション機能を追加したい

## やったこと
- [x] -r オプションを指定して逆順のファイル名一覧を表示できるようにした
- [x] generate_file_names というメソッド名をより適切な search_file_names に差し替えた

## 確認方法

ディレクトリに移動して ./ls.rb - rでファイル一覧を表示できること

```sh
$ cd 04.ls
$ ./ls.rb -r
```

- 実行結果
  - ![CleanShot 2024-10-30 at 16 09 12@2x](https://github.com/user-attachments/assets/b98f20c7-d90a-499f-92ca-31b1693eaeb6)
- lsコマンドとの比較
  - ![CleanShot 2024-10-30 at 16 09 57@2x](https://github.com/user-attachments/assets/c55108ee-07b2-466d-9601-4b9aeddf057c)
