### PR TITLE
Rubyプラクティス > lsコマンドを作る5

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -20,7 +20,7 @@ PERMISSIONS = {
 def main
   options = ARGV.getopts('arl')
   file_names = search_file_names(options)
-  options['l'] ? render_long_format_list(file_names) : render_list(file_names)
+  options['l'] ? render_long_format(file_names) : render_short_format(file_names)
 end
 
 def search_file_names(options = {})
@@ -29,10 +29,10 @@ def search_file_names(options = {})
   options['r'] ? filtered_file_names.reverse : filtered_file_names
 end
 
-def render_list(file_names)
+def render_short_format(file_names)
   padding_size = file_names.map(&:length).max + PADDING_MARGIN
-  file_name_nested_array = generate_file_name_nested_array(file_names)
-  file_name_nested_array.each do |row_file_names|
+  file_name_table = generate_file_name_table(file_names)
+  file_name_table.each do |row_file_names|
     row_file_names.each do |file_name|
       print file_name.ljust(padding_size)
     end
@@ -40,14 +40,14 @@ def render_list(file_names)
   end
 end
 
-def generate_file_name_nested_array(file_names)
+def generate_file_name_table(file_names)
   lack_count = file_names.length % COLUMN_SIZE
   filled_file_names = lack_count.positive? ? file_names.concat([''] * (COLUMN_SIZE - lack_count)) : file_names
   row_size = (filled_file_names.length / COLUMN_SIZE)
   filled_file_names.each_slice(row_size).to_a.transpose
 end
 
-def render_long_format_list(file_names)
+def render_long_format(file_names)
   file_details = generate_file_details(file_names)
   width_options = generate_width_options(file_details)
   total_blocks = file_details.sum { |file_detail| file_detail[:stat].blocks }

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -20,7 +20,7 @@ PERMISSIONS = {
 def main
   options = ARGV.getopts('arl')
   file_names = search_file_names(options)
-  options['l'] ? render_list(file_names) : render_table(file_names)
+  options['l'] ? render_long_format_list(file_names) : render_list(file_names)
 end
 
 def search_file_names(options = {})
@@ -29,10 +29,10 @@ def search_file_names(options = {})
   options['r'] ? filtered_file_names.reverse : filtered_file_names
 end
 
-def render_table(file_names)
+def render_list(file_names)
   padding_size = file_names.map(&:length).max + PADDING_MARGIN
-  file_name_table = generate_file_name_table(file_names)
-  file_name_table.each do |row_file_names|
+  file_name_nested_array = generate_file_name_nested_array(file_names)
+  file_name_nested_array.each do |row_file_names|
     row_file_names.each do |file_name|
       print file_name.ljust(padding_size)
     end
@@ -40,14 +40,14 @@ def render_table(file_names)
   end
 end
 
-def generate_file_name_table(file_names)
+def generate_file_name_nested_array(file_names)
   lack_count = file_names.length % COLUMN_SIZE
   filled_file_names = lack_count.positive? ? file_names.concat([''] * (COLUMN_SIZE - lack_count)) : file_names
   row_size = (filled_file_names.length / COLUMN_SIZE)
   filled_file_names.each_slice(row_size).to_a.transpose
 end
 
-def render_list(file_names)
+def render_long_format_list(file_names)
   file_details = generate_file_details(file_names)
   width_options = generate_width_options(file_details)
   total_blocks = file_details.sum { |file_detail| file_detail[:stat].blocks }


### PR DESCRIPTION
## 終了条件
- スクリーンショットは-a -l -r -al -alrオプションそれぞれの実行結果を貼ること
- -alrでも-lraでも-ralでも順番に関係なく実行できる必要があります。
- -ar -al -lr などオプションが2つの場合の組み合わせも自由に指定できるようにすること。

## スクリーンショット
- lsとの比較
  - -aオプション
      - ![CleanShot 2024-12-30 at 13 02 46@2x](https://github.com/user-attachments/assets/f65ebf14-1746-40b1-8408-5f9b161c584f)
  - -lオプション
      - ![CleanShot 2024-12-30 at 13 03 11@2x](https://github.com/user-attachments/assets/958416a9-9663-41fb-8efd-aa85a1b0309b)
  - -r オプション
      - ![CleanShot 2024-12-30 at 13 03 00@2x](https://github.com/user-attachments/assets/196f1a26-4935-4bea-9c23-dfd9a56c5b31)
  - -alオプション
      - ![CleanShot 2024-12-30 at 13 05 57@2x](https://github.com/user-attachments/assets/0d82149d-8a2d-4cda-9feb-67061ce222c9)
  - -alrオプション
      - ![CleanShot 2024-12-30 at 13 03 39@2x](https://github.com/user-attachments/assets/f9e92838-ca13-4f09-82c4-2de7450426d5)
  - -lra, -ralでも同じ表示になっていること
      - ![CleanShot 2024-12-30 at 13 05 00@2x](https://github.com/user-attachments/assets/2703ab35-cf8a-404e-ac73-1f177fcaa78a)
  - -ar, -al, -lr でも同様に動くこと
      - ![CleanShot 2024-12-30 at 13 05 46@2x](https://github.com/user-attachments/assets/f9ef58be-dd42-4b0f-b52a-9ceeb61c94b2)
      - ![CleanShot 2024-12-30 at 13 05 57@2x](https://github.com/user-attachments/assets/cd615a8b-2a85-4697-a9e0-e920ad2b3120)
      - ![CleanShot 2024-12-30 at 13 06 45@2x](https://github.com/user-attachments/assets/f040ee6e-02f7-4d30-980c-e06a42b1f9cb)
- rubocop実行結果
  -  ![CleanShot 2024-12-30 at 14 06 53@2x](https://github.com/user-attachments/assets/2f2bbe13-f7fa-4440-86b3-1ed7f095ed98)
